### PR TITLE
Add RSS feed for blog posts tagged 'important'

### DIFF
--- a/important.xml
+++ b/important.xml
@@ -1,0 +1,21 @@
+---
+layout: none
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ site.name | xml_escape }} - Important</title>
+    <description>Posts categorized as 'important'</description>
+    <link>{{ site.url }}</link>
+    <atom:link href="{{ site.url }}/feed.category.xml" rel="self" type="application/rss+xml" />
+    {% for post in site.categories.important limit:10 %}
+      <item>
+        <title>{{ post.title | xml_escape }}</title>
+        <description>{{ post.content | xml_escape }}</description>
+        <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <link>{{ site.url }}{{ post.url }}</link>
+        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+      </item>
+    {% endfor %}
+  </channel>
+</rss>


### PR DESCRIPTION
This is a prerequisite for [CocoaPods #1780](https://github.com/CocoaPods/CocoaPods/issues/1780). Right now this feed will be empty on deploy (there are currently no posts tagged 'important'), but I tested the template with an alternate category.
