### PR TITLE
[CocoaPods 0.36] Remove section about IBDesignable

### DIFF
--- a/_posts/2015-03-11-CocoaPods-0.36.markdown
+++ b/_posts/2015-03-11-CocoaPods-0.36.markdown
@@ -88,12 +88,6 @@ Furthermore we don't have to apply the build rules ourself to the resources as e
 This should decrease build times for project using Pods that include many resources.
 
 
-### `@IBDesignable` - Another Reason for Frameworks
-
-Xcode 6 allows you to preview your own custom view components in the interface builder.
-To make use of that, the view component must live in an own framework.
-
-
 ### More about Frameworks
 
 If you want to learn more about Frameworks, take a look into the [Framework Programming Guide](https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPFrameworks/Frameworks.html#//apple_ref/doc/uid/10000183-SW1).


### PR DESCRIPTION
This was only valid for some betas of Xcode. Meanwhile it builds also library targets for the interface builder, which isn't fully supported with CP yet, but that can be fixed.