### PR TITLE
[Post] Add missing excerpt seperator to 0.37 release post

### DIFF
--- a/_posts/2015-05-03-CocoaPods-0.37.markdown
+++ b/_posts/2015-05-03-CocoaPods-0.37.markdown
@@ -7,6 +7,8 @@ categories: cocoapods releases
 
 TL;DR: _CocoaPods 0.37_ has been released, with a new pod download cache and support for custom module maps.
 
+<!-- more -->
+
 CocoaPods 0.37 has been released, it includes download caching for Pods.
 This brings a huge speed improvement to commands such as `pod spec lint`
 and improves the performance of running `pod install` when a Pod is in


### PR DESCRIPTION
The code block which is shown otherwhise on the homepage is causing layout issues on larger viewports.

This is likely caused by the code block, which is part of the preview, as there was no excerpt separator (`<!-- more -->`) at all. This affects only viewports over `990px` width.

![screen shot 2015-05-03 at 11 00 04](https://cloud.githubusercontent.com/assets/1389011/7444581/133e273e-f18a-11e4-8e50-494cb02bf3d0.png)

This could be fixed with:
```css
.post {
  clear: both;
}
```
But as this is a style class defined in bootstrap which is  not affected by our own style definitions, I guess either our element hierarchy is wrong / not supported or it's a bug there.