### PR TITLE
Fix broken anchor link for Repairing Our Broken Specs Repository added in #110

### DIFF
--- a/_posts/2014-01-30-Repairing-Our-Broken-Specs-Repository.markdown
+++ b/_posts/2014-01-30-Repairing-Our-Broken-Specs-Repository.markdown
@@ -6,7 +6,7 @@ author: kyle
 categories: cocoapods
 ---
 
-_Note: If you got this problem after running `gem update`, [jump here](#user-content-i-got-linked-here-after-updating-my-gems-what-to-do) to find a solution._
+_Note: If you got this problem after running `gem update`, [jump here](#i-got-linked-here-after-updating-my-gems,-what-to-do?) to find a solution._
 
 Unfortunately we've encountered a bug in libgit2 and we are going to have to
 **force push** into [the Specs repository][master-repo]. (Also known as the


### PR DESCRIPTION
I was briefly confused when the _jump here_ link at the top of [Repairing Our Broken Specs Repository](http://blog.cocoapods.org/Repairing-Our-Broken-Specs-Repository/) didn't do anything. I'm guessing something changed in the element id generation on the blog since #110, so this updates the anchor.

Although maybe it's better to find the cause of the id generation change and revert it?

Thanks for an awesome project/blog!