### PR TITLE
Add a note about using a predates_sharding_branch branch

### DIFF
--- a/_posts/2016-10-28-Sharding.markdown
+++ b/_posts/2016-10-28-Sharding.markdown
@@ -25,7 +25,6 @@ To the top of your Podfile, and CocoaPods will only use the archived repo, inste
 <pre>
 <code>
 cd ~/.cocoapods/repos/master/
-git pull origin master
 git checkout predates_sharding_branch
 </code>
 </pre>

--- a/_posts/2016-10-28-Sharding.markdown
+++ b/_posts/2016-10-28-Sharding.markdown
@@ -25,9 +25,12 @@ To the top of your Podfile, and CocoaPods will only use the archived repo, inste
 <pre>
 <code>
 cd ~/.cocoapods/repos/master/
-git checkout predates_sharding_branch
+git fetch origin master
+git checkout v0.32.1
 </code>
 </pre>
+
+To run `pod install`, you will also  need to use `--no-repo-update`.
 
 We do not have the resources to maintain multiple versions of CocoaPods in our spare time, and so we recommend that instead of doing the above, you migrate to the latest versions of CocoaPods in your projects.
 

--- a/_posts/2016-10-28-Sharding.markdown
+++ b/_posts/2016-10-28-Sharding.markdown
@@ -20,7 +20,17 @@ source "https://github.com/CocoaPods/Old-Specs"
 </code>
 </pre>
 
-To the top of your Podfile, and CocoaPods will only use the archived repo, instead of using the new repo structure.
+To the top of your Podfile, and CocoaPods will only use the archived repo, instead of using the new repo structure. You will also need to set your local Specs repo to a version before the transition:
+
+<pre>
+<code>
+cd ~/.cocoapods/repos/master/
+git pull origin master
+git checkout predates_sharding_branch
+</code>
+</pre>
+
+We do not have the resources to maintain multiple versions of CocoaPods in our spare time, and so we recommend that instead of doing the above, you migrate to the latest versions of CocoaPods in your projects.
 
 ---
 


### PR DESCRIPTION
This should fix https://github.com/CocoaPods/CocoaPods/issues/6167 - I've pushed a branch to the Specs repo so that a `git pull` won't fail for 0.39 users with the master repo, which should make the update function work. 

For those without the Specs repo we might have to add some extra instructions?

@segiddins - this should work right?