### PR TITLE
Add blog post regarding CDN support 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,12 @@ authors:
     twitter: dnkoutso
     gravatar: 0da25866cffc79d7427beb50d984185a
 
+  igormaka:
+    name: Igor Makarov
+    twitter: igormaka
+    gravatar: ecfc4cf87073033b9ac1547872b5cf78
+
+
 assets:
   sources:
     - shared/img

--- a/_posts/2019-02-22-CocoaPods-1.7.0-beta.markdown
+++ b/_posts/2019-02-22-CocoaPods-1.7.0-beta.markdown
@@ -198,7 +198,7 @@ This reduces the amount of footprint CocoaPods has into the user project but als
 
 Along with 1.7.0 we are shipping a couple of exciting and important experimental features!
 
-#### CDN Support For The [Master Specs Repo](https://github.com/CocoaPods/Specs)
+#### <a name="cdn-support"></a>CDN Support For The [Master Specs Repo](https://github.com/CocoaPods/Specs)
 
 The [master specs repo](https://github.com/CocoaPods/Specs) is crucial to the functionality of CocoaPods, however, over the years its size has grown dramatically making it the number one difficulty to onboard with CocoaPods.
 

--- a/_posts/2019-06-14-CocoaPods-1.7.2.markdown
+++ b/_posts/2019-06-14-CocoaPods-1.7.2.markdown
@@ -84,5 +84,7 @@ If you have a CI setup, it is recommended to cache the new repo dir as it is ver
 
 In an upcoming release, we are planning to make the CDN source the default source!
 
+P.S. Thanks to [@dnkoutso](https://twitter.com/dnkoutso) for all the release work!
+
 
 🚀

--- a/_posts/2019-06-14-CocoaPods-1.7.2.markdown
+++ b/_posts/2019-06-14-CocoaPods-1.7.2.markdown
@@ -11,11 +11,11 @@ _CocoaPods 1.7.2_ brings with it the final version of CDN support for the [trunk
 
 It's been a tale of ridiculous scale, unintended consequences and free open-source plans. CocoaPods is moving to use a CDN which is located at https://cdn.cocoapods.org/ and is still considered experimental. A future release will make it the default spec source.
 
-A CDN is a Content Delivery Network - what this means for CocoaPods is that using CocoaPods won't require you to have a local copy of all the public Podspecs on your computer. Saving you about a GB of file storage, and shaving a lot of time from `pod install`s.
+A CDN is a Content Delivery Network - what this means for CocoaPods is that using CocoaPods won't require you to have a local copy of all the public Podspecs on your computer. Saving you about a GB of file storage, and shaving a lot of time off `pod install`s.
 
 ### Scaling when free and open source
 
-CocoaPods is a free, open-source project run by maintainers in their spare time. As such, it depends on the good graces and sponsorships of multiple tech companies. The initial decision was to store the specs in a git repo, a common practice for a free, open-source project for storing such metadata. 
+CocoaPods is a free, open-source project run by maintainers in their spare time. As such, it depends on the good graces and sponsorships of multiple tech companies. The initial decision was to store the specs in a GitHub repo, a common practice for a free, open-source project for storing such metadata. 
 
 The first hurdles of scale were encountered in 2016, when traffic to the master spec repo has caused GitHub to [rate-limit all operations]({% post_url 2016-05-04-Master-Spec-Repo-Rate-Limiting-Post-Mortem %}).  
 A [comment from GitHub](https://github.com/CocoaPods/CocoaPods/issues/4989#issuecomment-193772935) at the time stated that this repo alone was using 5 whole server CPUs and consuming terabytes upon terabytes of bandwidth.
@@ -54,11 +54,13 @@ The [final version](https://github.com/CocoaPods/Core/pull/541) of the CDN for C
 
 Upon each commit, Netlify runs a [specialized script](https://github.com/CocoaPods/Specs/tree/master/Scripts) which generates a per-shard index for all the pods and versions in the repo. If you've ever noticed that the directory structure for our Podspecs repo was strange, this is what we call sharding. An example of a shard index can be found at https://cdn.cocoapods.org/all_pods_versions_2_2_2.txt. This would correspond to `~/.cocoapods/repos/master/Specs/2/2/2/` locally. 
 
-Additionally, we create an `all_pods.txt` contains a list of all pods, finally any other request made is redirected to GitHub's CDN.
+Additionally, we create an `all_pods.txt` file which contains a list of all pods.  
+
+Finally, any other request made is redirected to GitHub's CDN.
 
 ### Usage
 
-Using the CDN for retrieving specs, while "finalized" and we're happy, it should still be considered experimental until we switch it to be default.
+Using the CDN for retrieving specs, while "finalized", should still be considered experimental until we switch it to be default.
 
 To use the CDN source in your `Podfile`:
 
@@ -78,7 +80,7 @@ source 'https://github.com/artsy/Specs.git'
 
 Doing this will break your `Podfile.lock`, so you are likely to need to run `pod update` to see the changes (be careful, this may update your Pods also).
 
-If you have a CI setup, it is recommended to cache the new repo dir as it is very small and would save even more time. With 1.7.2 it should be located at `~/.cocoapods/repos/cocoapods-` but we're looking to improve the name in an upcoming release.
+If you have a CI setup, it is recommended to cache the new repo dir as it is very small and would save even more time. With 1.7.2 it should be located at `~/.cocoapods/repos/cocoapods-`, but we're looking to improve the name in an upcoming release.
 
 In an upcoming release, we are planning to make the CDN source the default source!
 

--- a/_posts/2019-06-14-CocoaPods-1.7.2.markdown
+++ b/_posts/2019-06-14-CocoaPods-1.7.2.markdown
@@ -80,7 +80,7 @@ source 'https://github.com/artsy/Specs.git'
 
 Doing this will break your `Podfile.lock`, so you are likely to need to run `pod update` to see the changes (be careful, this may update your Pods also).
 
-If you have a CI setup, it is recommended to cache the new repo dir as it is very small and would save even more time. With 1.7.2 it should be located at `~/.cocoapods/repos/cocoapods-`, but we're looking to improve the name in an upcoming release.
+If you have a CI setup, it is recommended to cache the new repo dir as it is very small and would save even more time. With 1.7.2 it should be located at `~/.cocoapods/repos/cocoapods-` (yes, with a `-`), but we're looking to improve the naming in an upcoming release.
 
 In an upcoming release, we are planning to make the CDN source the default source!
 

--- a/_posts/2019-06-14-CocoaPods-1.7.2.markdown
+++ b/_posts/2019-06-14-CocoaPods-1.7.2.markdown
@@ -1,0 +1,78 @@
+---
+layout: post
+title:  "CocoaPods 1.7.2 - Master Repo CDN is Finalized!"
+author: igormaka
+categories: cocoapods releases
+---
+
+_CocoaPods 1.7.2_ brings with it the final version of CDN support for the [master spec repo](https://github.com/CocoaPods/Specs). 
+
+<!-- more -->
+
+It's been a tale of ridiculous scale, unintended consequences and free open-source plans.  
+The CDN is located at https://cdn.cocoapods.org/ and is still considered experimental.   
+A future release will make it the default spec source.
+
+### Scaling when free and open source
+
+CocoaPods is a free, open-source project. As such, it depends on the good graces and sponsorships of multiple tech companies. The initial decision was to store the specs in a git repo, a common practice for a free, open-source project for storing such metadata. 
+
+The first hurdles of scale were encountered in 2016, when traffic to the master spec repo has caused GitHub to [rate-limit all operations]({% post_url 2016-05-04-Master-Spec-Repo-Rate-Limiting-Post-Mortem %}).  
+A [comment from GitHub](https://github.com/CocoaPods/CocoaPods/issues/4989#issuecomment-193772935) at the time stated that this repo alone was using 5 whole server CPUs and consuming terabytes upon terabytes of bandwidth.
+
+The crisis was averted by [sharding the repo]({% post_url 2016-10-28-Sharding %}) to improve algorithmic performance and by limiting all first-time clones to being shallow. 
+
+This has solved GitHub's problem, but CocoaPods' users still had to deal with unsatisfactory performance.
+
+### Git as a database
+
+Git was invented at a time when "slow network" and "no backups" were legitimate design concerns. Running endless builds as part of continuous integration wasn't commonplace. CDN wasn't so commonly available.
+
+There are many stories of git repos hitting the hard envelope of git's design constraints. [Microsoft's Windows repo](https://devblogs.microsoft.com/bharry/the-largest-git-repo-on-the-planet/) is one example. CocoaPods is another.
+
+At the time of writing, the spec repo had:
+
+* almost 400k commits - half of the Linux Kernel repo!
+* over 400k directories
+* over 300k spec files
+
+These numbers have caused the repo to take minutes to clone, long times to update and have wasted uncountable CI time. It has also proven to be resistant to tarballing, as this sort of directory structure hits a bottleneck in `tar` as well. 
+
+### Directory Listing Denied
+
+It was obvious to many that the spec repo should be put behind a CDN, but there were several constraints:
+
+1. It had to be a free CDN, as the project is free and open-source.
+2. It had to allow some way of obtaining directory listings, for retrieving versions of pods.
+3. It had to auto-update from GitHub as the source of truth.
+
+The first implementation was a shell script, polling GitHub and piping `find` into `ls` into index files. This ran on a machine that was not open or free and therefore could not be the true soultion.  
+Nevertheless, this auto-updated repo was put behind a [jsDelivr CDN](https://www.jsdelivr.com) and the client interfacing with it was released in [1.7.0]({% post_url 2019-02-22-CocoaPods-1.7.0-beta %}#cdn-support) labeled "highly experimental".
+
+### Final Lap with Netlify
+
+The final version of the CDN for CocoaPods/Specs was implemented on [Netlify](https://www.netlify.com), a static site hosting service supporting flexible site generation.   
+This solution ticked all the boxes: a generous open-source plan, fast CDN and continuous deployment from GitHub.
+
+Upon each commit, Netlify runs a specialized script that generates a per-shard index for all the pods and versions in the repo. An example of a shard index can be found at https://cdn.cocoapods.org/all_pods_versions_2_2_2.txt. Additionally, an `all_pods.txt` contains a list of all pods. 
+
+The rest of the requests get redirected to GitHub's CDN.
+
+### Usage
+
+Using the CDN for retrieving specs, while "finalized", should still be considered experimental.
+
+To use the CDN source in your `Podfile`, simply add it like so:
+
+```ruby
+source 'https://cdn.cocoapods.org/'
+```
+
+If you have a source-controlled `Podfile.lock` in your repo, it currently requires a manual update. Otherwise, just delete it.
+
+If you have a CI setup, it is recommended to cache the new repo dir as it is very small and would save even more time.
+
+In the next releases, we are planning to make the CDN source the default master source.
+
+
+🚀


### PR DESCRIPTION
Hi, I've prepared a writeup of the CDN support we just shipped.

I've also made a PR in [Specs#14415](https://github.com/CocoaPods/Specs/pull/14415) so that the root URL of `https://cdn.cocoapods.org/` redirects to the blog post.