### PR TITLE
Switch to full-text RSS feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -12,13 +12,7 @@ layout: none
     {% unless post.link %}
     <item>
       <title>{{ post.title }}</title>
-
-      {% if post.content contains '<!-- more -->' %}
-      <description>{{ post.content | split:'<!-- more -->' | first | xml_escape }}</description>  
-      {% else %}
       <description>{{ post.content | xml_escape }}</description>
-      {% endif %}
-
       <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
       <link>{{ site.url }}{{ post.url }}</link>
       <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>


### PR DESCRIPTION
As an RSS user, I always prefer full-text feeds, and I’m pretty sure most other RSS users do as well. And since the whole endeavor is open-source, it’s not like reading the article in RSS is depriving CocoaPods of ad revenue or tracking info, or the other reasons usually cited for turning off full-text in feeds.