### PR TITLE
Housekeeping tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ categories: tags that are relevant
 ---
 ```
 
+Use Jekyll's `post_url` function to link to other posts, as this provides build-time validation of links.  
+If a link repeats several times throughout the post, use [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links).
+
 ## Deployment
 
 Run `rake deploy` to push to site the gh-pages branch.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add a nickname for you followed by your full name, twitter handle and gravatar h
 
 Create a new file in _post directory following the format year-month-day-blog-post-title.markdown
 
-Start the post using Jekylls [Front Matter](http://jekyllrb.com/docs/frontmatter/):
+Start the post using Jekyll's [Front Matter](http://jekyllrb.com/docs/frontmatter/):
 
 ```
 ---

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ categories: tags that are relevant
 ---
 ```
 
-Use Jekyll's `post_url` function to link to other posts, as this provides build-time validation of links.
+Use Jekyll's `post_url` function to link to other posts, as this provides build-time validation of links. The function takes the full post filename minus the extension.  
 If a link repeats several times throughout the post, use [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links).  
-Example of using both:
+Example of using both:  
 ```markdown
 CDN support was first introduced in the [1.7 release][1.7] and was finalized in [1.7.2].
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,15 @@ categories: tags that are relevant
 ---
 ```
 
-Use Jekyll's `post_url` function to link to other posts, as this provides build-time validation of links.  
-If a link repeats several times throughout the post, use [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links).
+Use Jekyll's `post_url` function to link to other posts, as this provides build-time validation of links.
+If a link repeats several times throughout the post, use [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links).  
+Example of using both:
+```markdown
+CDN support was first introduced in the [1.7 release][1.7] and was finalized in [1.7.2].
+
+[1.7]: {% post_url 2019-02-22-CocoaPods-1.7.0-beta %}
+[1.7.2]: {% post_url 2019-06-14-CocoaPods-1.7.2 %}
+```
 
 ## Deployment
 

--- a/_layouts/rss.xml
+++ b/_layouts/rss.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  {{ content }}
+</rss>

--- a/_posts/2018-03-16-CocoaPods-Metadata-Service.markdown
+++ b/_posts/2018-03-16-CocoaPods-Metadata-Service.markdown
@@ -84,7 +84,7 @@ As we rely more on this service, we can continue to provide the rich web-experie
 to maintain infrastructure, which paves the way for CocoaPods to continue being a useful resource for a very long time.
 
 [cms]: https://github.com/CocoaPods/cocoapods-metadata-service
-[cd_down]: https://blog.cocoapods.org/CocoaDocs-Documentation-Sunsetting
+[cd_down]: {% post_url 2017-03-28-CocoaDocs-Documentation-Sunsetting %}
 [bb]: http://buddybuild.com
 [appl]: https://www.buddybuild.com/blog/buddybuild-is-now-part-of-apple
 [eth]: https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem

--- a/_posts/2019-02-22-CocoaPods-1.7.0-beta.markdown
+++ b/_posts/2019-02-22-CocoaPods-1.7.0-beta.markdown
@@ -69,7 +69,7 @@ Finally, a warning will be displayed during `lint` that encourages pod authors t
 
 ### App Specs
 
-With the recently introduced [test specs](http://blog.cocoapods.org/CocoaPods-1.3.0) we were able to build a platform for us to expand on and introduce different types of specifications that can be provided by a pod author. With 1.7.0, we are introducing _app specs_ which allow pod authors to describe an application from within their `podspec`.
+With the recently introduced [test specs]({% post_url 2017-08-01-CocoaPods-1.3.0 %}) we were able to build a platform for us to expand on and introduce different types of specifications that can be provided by a pod author. With 1.7.0, we are introducing _app specs_ which allow pod authors to describe an application from within their `podspec`.
 
 App specs can help pod authors in various ways, for example, they can be used to ship a sample app alongside their pod as a tutorial on how consumers can integrate it to their own respective app.
 

--- a/_posts/2019-08-05-CocoaPods-1.8.0-beta.markdown
+++ b/_posts/2019-08-05-CocoaPods-1.8.0-beta.markdown
@@ -11,7 +11,7 @@ _CocoaPods 1.8_ switches the CDN as the default spec repo source and comes with 
 
 ### CDN as Default
 
-CDN support was first introduced in the [1.7 release](http://blog.cocoapods.org/CocoaPods-1.7.0-beta/) and was finalized in [1.7.2](http://blog.cocoapods.org/CocoaPods-1.7.2/). It aims to speed up initial setup and dependency analysis dramatically. With 1.8, CocoaPods _no longer_ requires cloning the now huge [master specs repo](https://github.com/CocoaPods/Specs) in order to function and users may integrate their projects with CocoaPods almost instantly.
+CDN support was first introduced in the [1.7 release][1.7] and was finalized in [1.7.2]. It aims to speed up initial setup and dependency analysis dramatically. With 1.8, CocoaPods _no longer_ requires cloning the now huge [master specs repo](https://github.com/CocoaPods/Specs) in order to function and users may integrate their projects with CocoaPods almost instantly.
 
 Here's video demonstration of integrating and building an iOS project with a fresh install of CocoaPods 1.8 in _less than a minute_:
 
@@ -38,7 +38,7 @@ pod repo remove master
 
 **Note**: If you wish to continue using the `git` based source then you must ensure it is _explicitly_ specified in your `Podfile` via the `source` DSL, otherwise CocoaPods will automatically use CDN for dependency resolution.
 
-And that's it! For more information regarding CDN, please read our previous blog post [here](https://blog.cocoapods.org/CocoaPods-1.7.2/)!
+And that's it! For more information regarding CDN, please read our previous blog post [here][1.7.2]!
 
 ### `info_plist` Podspec DSL
 
@@ -62,7 +62,7 @@ Pod::Spec.new do |s|
 end
 ```
 
-With app specs introduced in [1.7](https://blog.cocoapods.org/CocoaPods-1.7.0-beta/), pod authors were able to describe an application, such as a demo app, for their pods. The new `info_plist` DSL enhances the functionality of app specs even further by allowing podspecs to customize the generated `Info.plist`, which contains important settings such as the bundle identifier, iOS security and privacy settings, device orientation support, and more.
+With app specs introduced in [1.7], pod authors were able to describe an application, such as a demo app, for their pods. The new `info_plist` DSL enhances the functionality of app specs even further by allowing podspecs to customize the generated `Info.plist`, which contains important settings such as the bundle identifier, iOS security and privacy settings, device orientation support, and more.
 
 ```ruby
 Pod::Spec.new do |s|
@@ -93,7 +93,7 @@ For more details on how this works and the rational behind it, check out the RFC
 
 ### `project_name` Podfile DSL
 
-CocoaPods [1.7](https://blog.cocoapods.org/CocoaPods-1.7.0-beta/) introduced the [`generate_multiple_pod_projects`](https://guides.cocoapods.org/syntax/podfile.html#install_bang) option that installs each pod into its own Xcode project. CocoaPods 1.8 expands further by introducing the `project_name` DSL that allows pod consumers to specify the project name to integrate a given pod.
+CocoaPods [1.7] introduced the [`generate_multiple_pod_projects`](https://guides.cocoapods.org/syntax/podfile.html#install_bang) option that installs each pod into its own Xcode project. CocoaPods 1.8 expands further by introducing the `project_name` DSL that allows pod consumers to specify the project name to integrate a given pod.
 
 This opens up plenty of new possibilities for consumers to _group_ certain pods together that make sense logically. Consider the following example:
 
@@ -208,3 +208,6 @@ As always, we would like to thank all of our contributors for making this releas
 Checkout the [changelog](https://github.com/CocoaPods/CocoaPods/releases/tag/1.8.0.beta.1) to get the full list of changes.
 
 🚀
+
+[1.7]: {% post_url 2019-02-22-CocoaPods-1.7.0-beta %}
+[1.7.2]: {% post_url 2019-06-14-CocoaPods-1.7.2 %}

--- a/feed.xml
+++ b/feed.xml
@@ -1,23 +1,20 @@
 ---
-layout: none
+layout: rss
 ---
-<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>{{ site.name }}</title>
-    <description>{{ site.description }}</description>
-    <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/feed.articles.xml" rel="self" type="application/rss+xml" />
-    {% for post in site.posts %}
-    {% unless post.link %}
-    <item>
-      <title>{{ post.title }}</title>
-      <description>{{ post.content | xml_escape }}</description>
-      <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-      <link>{{ site.url }}{{ post.url }}</link>
-      <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-    </item>
-    {% endunless %}
-    {% endfor %}
-  </channel>
-</rss>
+<channel>
+  <title>{{ site.name }}</title>
+  <description>{{ site.description }}</description>
+  <link>{{ site.url }}</link>
+  <atom:link href="{{ site.url }}/feed.articles.xml" rel="self" type="application/rss+xml" />
+  {% for post in site.posts %}
+  {% unless post.link %}
+  <item>
+    <title>{{ post.title }}</title>
+    <description>{{ post.content | xml_escape }}</description>
+    <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+    <link>{{ site.url }}{{ post.url }}</link>
+    <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+  </item>
+  {% endunless %}
+  {% endfor %}
+</channel>

--- a/important.xml
+++ b/important.xml
@@ -1,21 +1,18 @@
 ---
-layout: none
+layout: rss
 ---
-<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>{{ site.name | xml_escape }} - Important</title>
-    <description>Posts categorized as 'important'</description>
-    <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/feed.category.xml" rel="self" type="application/rss+xml" />
-    {% for post in site.categories.important limit:10 %}
-      <item>
-        <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <link>{{ site.url }}{{ post.url }}</link>
-        <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-      </item>
-    {% endfor %}
-  </channel>
-</rss>
+<channel>
+  <title>{{ site.name | xml_escape }} - Important</title>
+  <description>Posts categorized as 'important'</description>
+  <link>{{ site.url }}</link>
+  <atom:link href="{{ site.url }}/feed.category.xml" rel="self" type="application/rss+xml" />
+  {% for post in site.categories.important limit:10 %}
+    <item>
+      <title>{{ post.title | xml_escape }}</title>
+      <description>{{ post.content | xml_escape }}</description>
+      <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+      <link>{{ site.url }}{{ post.url }}</link>
+      <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+    </item>
+  {% endfor %}
+</channel>


### PR DESCRIPTION
* Use Jekyll's `post_url` for build-time checking of inter-post links (year 2018 and up)
* Use markdown reference links to avoid repetitive `post_url` clutter
* Add example on how to use both to the README
* Fix the warning about RSS files having `layout: none`